### PR TITLE
templates: Add development scripts example

### DIFF
--- a/templates/development-scripts/examples/greet.py
+++ b/templates/development-scripts/examples/greet.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+from development_scripts import main
+
+
+if __name__ == "__main__":
+    main()

--- a/templates/development-scripts/flake.nix
+++ b/templates/development-scripts/flake.nix
@@ -1,0 +1,104 @@
+{
+  description = "Using Nix Flake apps to run scripts with uv2nix";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+    pyproject-nix = {
+      url = "github:pyproject-nix/pyproject.nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    uv2nix = {
+      url = "github:pyproject-nix/uv2nix";
+      inputs.pyproject-nix.follows = "pyproject-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    pyproject-build-systems = {
+      url = "github:pyproject-nix/build-system-pkgs";
+      inputs.pyproject-nix.follows = "pyproject-nix";
+      inputs.uv2nix.follows = "uv2nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    {
+      nixpkgs,
+      uv2nix,
+      pyproject-nix,
+      pyproject-build-systems,
+      ...
+    }:
+    let
+      inherit (nixpkgs) lib;
+      inherit (lib) filterAttrs hasSuffix;
+
+      workspace = uv2nix.lib.workspace.loadWorkspace { workspaceRoot = ./.; };
+
+      overlay = workspace.mkPyprojectOverlay {
+        sourcePreference = "wheel"; # or sourcePreference = "sdist";
+      };
+
+      pyprojectOverrides = _final: _prev: {
+        # Implement build fixups here.
+      };
+
+      pkgs = nixpkgs.legacyPackages.x86_64-linux;
+
+      python = pkgs.python312;
+
+      pythonSet =
+        (pkgs.callPackage pyproject-nix.build.packages {
+          inherit python;
+        }).overrideScope
+          (
+            lib.composeManyExtensions [
+              pyproject-build-systems.overlays.default
+              overlay
+              pyprojectOverrides
+            ]
+          );
+
+      venv = pythonSet.mkVirtualEnv "development-scripts-default-env" workspace.deps.default;
+    in
+    {
+
+      apps.x86_64-linux =
+        let
+          # Example base directory
+          basedir = ./examples;
+
+          # Get a list of regular Python files in example directory
+          files = filterAttrs (name: type: type == "regular" && hasSuffix ".py" name) (
+            builtins.readDir basedir
+          );
+
+        in
+        # Map over files to:
+        # - Rewrite script shebangs as shebangs pointing to the virtualenv
+        # - Strip .py suffixes from attribute names
+        #   Making a script "greet.py" runnable as "nix run .#greet"
+        lib.mapAttrs' (
+          name: _:
+          lib.nameValuePair (lib.removeSuffix ".py" name) (
+            let
+              script = basedir + "/${name}";
+
+              # Patch script shebang
+              program = pkgs.runCommand name { buildInputs = [ venv ]; } ''
+                cp ${script} $out
+                chmod +x $out
+                patchShebangs $out
+              '';
+            in
+            {
+              type = "app";
+              program = "${program}";
+            }
+          )
+        ) files;
+
+    };
+}

--- a/templates/development-scripts/pyproject.toml
+++ b/templates/development-scripts/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "development-scripts"
+version = "0.1.0"
+description = "Add your description here"
+readme = "README.md"
+authors = [
+    { name = "adisbladis", email = "adisbladis@gmail.com" }
+]
+requires-python = ">=3.12"
+dependencies = []
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/templates/development-scripts/src/development_scripts/__init__.py
+++ b/templates/development-scripts/src/development_scripts/__init__.py
@@ -1,0 +1,2 @@
+def main() -> None:
+    print("Hello from development-scripts!")

--- a/templates/development-scripts/uv.lock
+++ b/templates/development-scripts/uv.lock
@@ -1,0 +1,7 @@
+version = 1
+requires-python = ">=3.12"
+
+[[package]]
+name = "development-scripts"
+version = "0.1.0"
+source = { editable = "." }


### PR DESCRIPTION
Add an example showing how to run development scripts that aren't shipped as a part of the application. This example shows one strategy for taking a pile of scripts from a directory and making them runnable using `nix run`.