### PR TITLE
templates.hello-world: Set LD_LIBRARY_PATH to manylinux1 path

### DIFF
--- a/templates/hello-world/flake.nix
+++ b/templates/hello-world/flake.nix
@@ -104,9 +104,18 @@
             python
             pkgs.uv
           ];
+          env =
+            {
+              # Prevent uv from managing Python downloads
+              UV_PYTHON_DOWNLOADS = "never";
+            }
+            // lib.optionalAttrs pkgs.stdenv.isLinux {
+              # Python libraries often load native shared objects using dlopen(3).
+              # Setting LD_LIBRARY_PATH makes the dynamic library loader aware of libraries without using RPATH for lookup.
+              LD_LIBRARY_PATH = lib.makeLibraryPath pkgs.pythonManylinuxPackages.manylinux1;
+            };
           shellHook = ''
             unset PYTHONPATH
-            export UV_PYTHON_DOWNLOADS=never
           '';
         };
 


### PR DESCRIPTION
This makes the impure development environment more manylinux compliant. Most notably this makes `libstdc++.so.6` available in the environment.