### PR TITLE
Typo: parseVersionCond was used instead of parseVersionConds when parsing version specifiers from the lockfile

### DIFF
--- a/lib/expected/lock1.filterPackage.testMultiChoicePackage.json
+++ b/lib/expected/lock1.filterPackage.testMultiChoicePackage.json
@@ -35,22 +35,24 @@
         },
         "name": "arpeggio",
         "path": null,
-        "specifier": {
-          "op": "==",
-          "version": {
-            "dev": null,
-            "epoch": 0,
-            "local": null,
-            "post": null,
-            "pre": null,
-            "release": [
-              2,
-              0,
-              2
-            ],
-            "str": "2.0.2"
+        "specifier": [
+          {
+            "op": "==",
+            "version": {
+              "dev": null,
+              "epoch": 0,
+              "local": null,
+              "post": null,
+              "pre": null,
+              "release": [
+                2,
+                0,
+                2
+              ],
+              "str": "2.0.2"
+            }
           }
-        },
+        ],
         "url": null
       },
       {
@@ -84,22 +86,24 @@
         },
         "name": "arpeggio",
         "path": null,
-        "specifier": {
-          "op": "==",
-          "version": {
-            "dev": null,
-            "epoch": 0,
-            "local": null,
-            "post": null,
-            "pre": null,
-            "release": [
-              2,
-              0,
-              1
-            ],
-            "str": "2.0.1"
+        "specifier": [
+          {
+            "op": "==",
+            "version": {
+              "dev": null,
+              "epoch": 0,
+              "local": null,
+              "post": null,
+              "pre": null,
+              "release": [
+                2,
+                0,
+                1
+              ],
+              "str": "2.0.1"
+            }
           }
-        },
+        ],
         "url": null
       }
     ]

--- a/lib/expected/lock1.parsePackage.testLocal.json
+++ b/lib/expected/lock1.parsePackage.testLocal.json
@@ -21,22 +21,24 @@
         "marker": null,
         "name": "certifi",
         "path": null,
-        "specifier": {
-          "op": ">=",
-          "version": {
-            "dev": null,
-            "epoch": 0,
-            "local": null,
-            "post": null,
-            "pre": null,
-            "release": [
-              2024,
-              7,
-              4
-            ],
-            "str": "2024.7.4"
+        "specifier": [
+          {
+            "op": ">=",
+            "version": {
+              "dev": null,
+              "epoch": 0,
+              "local": null,
+              "post": null,
+              "pre": null,
+              "release": [
+                2024,
+                7,
+                4
+              ],
+              "str": "2024.7.4"
+            }
           }
-        },
+        ],
         "url": null
       }
     ]

--- a/lib/expected/lock1.parsePackage.testLocalSdist.json
+++ b/lib/expected/lock1.parsePackage.testLocalSdist.json
@@ -177,21 +177,23 @@
         },
         "name": "coverage",
         "path": null,
-        "specifier": {
-          "op": ">=",
-          "version": {
-            "dev": null,
-            "epoch": 0,
-            "local": null,
-            "post": null,
-            "pre": null,
-            "release": [
-              5,
-              3
-            ],
-            "str": "5.3"
+        "specifier": [
+          {
+            "op": ">=",
+            "version": {
+              "dev": null,
+              "epoch": 0,
+              "local": null,
+              "post": null,
+              "pre": null,
+              "release": [
+                5,
+                3
+              ],
+              "str": "5.3"
+            }
           }
-        },
+        ],
         "url": null
       },
       {
@@ -394,22 +396,24 @@
         },
         "name": "mypy",
         "path": null,
-        "specifier": {
-          "op": ">=",
-          "version": {
-            "dev": null,
-            "epoch": 0,
-            "local": null,
-            "post": null,
-            "pre": null,
-            "release": [
-              1,
-              1,
-              1
-            ],
-            "str": "1.1.1"
+        "specifier": [
+          {
+            "op": ">=",
+            "version": {
+              "dev": null,
+              "epoch": 0,
+              "local": null,
+              "post": null,
+              "pre": null,
+              "release": [
+                1,
+                1,
+                1
+              ],
+              "str": "1.1.1"
+            }
           }
-        },
+        ],
         "url": null
       },
       {
@@ -447,22 +451,24 @@
         },
         "name": "mypy",
         "path": null,
-        "specifier": {
-          "op": ">=",
-          "version": {
-            "dev": null,
-            "epoch": 0,
-            "local": null,
-            "post": null,
-            "pre": null,
-            "release": [
-              1,
-              1,
-              1
-            ],
-            "str": "1.1.1"
+        "specifier": [
+          {
+            "op": ">=",
+            "version": {
+              "dev": null,
+              "epoch": 0,
+              "local": null,
+              "post": null,
+              "pre": null,
+              "release": [
+                1,
+                1,
+                1
+              ],
+              "str": "1.1.1"
+            }
           }
-        },
+        ],
         "url": null
       },
       {
@@ -500,22 +506,24 @@
         },
         "name": "mypy",
         "path": null,
-        "specifier": {
-          "op": ">=",
-          "version": {
-            "dev": null,
-            "epoch": 0,
-            "local": null,
-            "post": null,
-            "pre": null,
-            "release": [
-              1,
-              1,
-              1
-            ],
-            "str": "1.1.1"
+        "specifier": [
+          {
+            "op": ">=",
+            "version": {
+              "dev": null,
+              "epoch": 0,
+              "local": null,
+              "post": null,
+              "pre": null,
+              "release": [
+                1,
+                1,
+                1
+              ],
+              "str": "1.1.1"
+            }
           }
-        },
+        ],
         "url": null
       },
       {
@@ -553,22 +561,24 @@
         },
         "name": "mypy",
         "path": null,
-        "specifier": {
-          "op": ">=",
-          "version": {
-            "dev": null,
-            "epoch": 0,
-            "local": null,
-            "post": null,
-            "pre": null,
-            "release": [
-              1,
-              1,
-              1
-            ],
-            "str": "1.1.1"
+        "specifier": [
+          {
+            "op": ">=",
+            "version": {
+              "dev": null,
+              "epoch": 0,
+              "local": null,
+              "post": null,
+              "pre": null,
+              "release": [
+                1,
+                1,
+                1
+              ],
+              "str": "1.1.1"
+            }
           }
-        },
+        ],
         "url": null
       },
       {
@@ -744,22 +754,24 @@
         },
         "name": "pytest",
         "path": null,
-        "specifier": {
-          "op": ">=",
-          "version": {
-            "dev": null,
-            "epoch": 0,
-            "local": null,
-            "post": null,
-            "pre": null,
-            "release": [
-              4,
-              3,
-              0
-            ],
-            "str": "4.3.0"
+        "specifier": [
+          {
+            "op": ">=",
+            "version": {
+              "dev": null,
+              "epoch": 0,
+              "local": null,
+              "post": null,
+              "pre": null,
+              "release": [
+                4,
+                3,
+                0
+              ],
+              "str": "4.3.0"
+            }
           }
-        },
+        ],
         "url": null
       },
       {
@@ -781,22 +793,24 @@
         },
         "name": "pytest",
         "path": null,
-        "specifier": {
-          "op": ">=",
-          "version": {
-            "dev": null,
-            "epoch": 0,
-            "local": null,
-            "post": null,
-            "pre": null,
-            "release": [
-              4,
-              3,
-              0
-            ],
-            "str": "4.3.0"
+        "specifier": [
+          {
+            "op": ">=",
+            "version": {
+              "dev": null,
+              "epoch": 0,
+              "local": null,
+              "post": null,
+              "pre": null,
+              "release": [
+                4,
+                3,
+                0
+              ],
+              "str": "4.3.0"
+            }
           }
-        },
+        ],
         "url": null
       },
       {
@@ -818,22 +832,24 @@
         },
         "name": "pytest",
         "path": null,
-        "specifier": {
-          "op": ">=",
-          "version": {
-            "dev": null,
-            "epoch": 0,
-            "local": null,
-            "post": null,
-            "pre": null,
-            "release": [
-              4,
-              3,
-              0
-            ],
-            "str": "4.3.0"
+        "specifier": [
+          {
+            "op": ">=",
+            "version": {
+              "dev": null,
+              "epoch": 0,
+              "local": null,
+              "post": null,
+              "pre": null,
+              "release": [
+                4,
+                3,
+                0
+              ],
+              "str": "4.3.0"
+            }
           }
-        },
+        ],
         "url": null
       },
       {
@@ -855,22 +871,24 @@
         },
         "name": "pytest",
         "path": null,
-        "specifier": {
-          "op": ">=",
-          "version": {
-            "dev": null,
-            "epoch": 0,
-            "local": null,
-            "post": null,
-            "pre": null,
-            "release": [
-              4,
-              3,
-              0
-            ],
-            "str": "4.3.0"
+        "specifier": [
+          {
+            "op": ">=",
+            "version": {
+              "dev": null,
+              "epoch": 0,
+              "local": null,
+              "post": null,
+              "pre": null,
+              "release": [
+                4,
+                3,
+                0
+              ],
+              "str": "4.3.0"
+            }
           }
-        },
+        ],
         "url": null
       },
       {

--- a/lib/expected/lock1.parsePackage.testMetadataRequiresDistMany.json
+++ b/lib/expected/lock1.parsePackage.testMetadataRequiresDistMany.json
@@ -143,22 +143,24 @@
         "marker": null,
         "name": "requests",
         "path": null,
-        "specifier": {
-          "op": ">=",
-          "version": {
-            "dev": null,
-            "epoch": 0,
-            "local": null,
-            "post": null,
-            "pre": null,
-            "release": [
-              2,
-              32,
-              3
-            ],
-            "str": "2.32.3"
+        "specifier": [
+          {
+            "op": ">=",
+            "version": {
+              "dev": null,
+              "epoch": 0,
+              "local": null,
+              "post": null,
+              "pre": null,
+              "release": [
+                2,
+                32,
+                3
+              ],
+              "str": "2.32.3"
+            }
           }
-        },
+        ],
         "url": null
       },
       {

--- a/lib/expected/lock1.parsePackage.testWithExtra.json
+++ b/lib/expected/lock1.parsePackage.testWithExtra.json
@@ -25,22 +25,24 @@
         "marker": null,
         "name": "requests",
         "path": null,
-        "specifier": {
-          "op": ">=",
-          "version": {
-            "dev": null,
-            "epoch": 0,
-            "local": null,
-            "post": null,
-            "pre": null,
-            "release": [
-              2,
-              32,
-              3
-            ],
-            "str": "2.32.3"
+        "specifier": [
+          {
+            "op": ">=",
+            "version": {
+              "dev": null,
+              "epoch": 0,
+              "local": null,
+              "post": null,
+              "pre": null,
+              "release": [
+                2,
+                32,
+                3
+              ],
+              "str": "2.32.3"
+            }
           }
-        },
+        ],
         "url": null
       }
     ]

--- a/lib/lock1.nix
+++ b/lib/lock1.nix
@@ -366,6 +366,7 @@ fix (self: {
               git ? null,
               specifier ? null,
               extras ? null,
+              ...
             }:
             {
               inherit
@@ -378,7 +379,7 @@ fix (self: {
                 extras
                 ;
               marker = if marker != null then parseMarkers marker else null;
-              specifier = if specifier != null then pep440.parseVersionCond specifier else null;
+              specifier = if specifier != null then pep440.parseVersionConds specifier else null;
             };
         in
         {


### PR DESCRIPTION
This fixes the issue that the `requires-dist` field in package metadata from `uv.lock` may include comma-separated specs.