### PR TITLE
Add missing `mainProgram` to `uv-bin`

### DIFF
--- a/pkgs/uv-bin/default.nix
+++ b/pkgs/uv-bin/default.nix
@@ -39,6 +39,7 @@ stdenv.mkDerivation (
     '';
 
     meta = {
+      mainProgram = "uv";
       license = [
         lib.licenses.asl20
         lib.licenses.mit


### PR DESCRIPTION
I wanted to test out https://github.com/pyproject-nix/uv2nix/pull/104,
but I needed a version of `uv` that supports locking scripts. I noticed
this flake conviniently has a shiny version of `uv`.

Before:

    $ nix run github:pyproject-nix/uv2nix#uv-bin
    error: unable to execute '/nix/store/7g6300asphk9387djdh5sxh6kdhwkqn7-uv-bin-0.5.17/bin/uv-bin': No such file or directory

Before:

    $ nix run .#uv-bin -- --version
    uv 0.5.18
