### PR TITLE
fix(lockfile): allow arbitrary new fields in `uv.lock`

### DIFF
--- a/lib/lock1.nix
+++ b/lib/lock1.nix
@@ -298,6 +298,7 @@ fix (self: {
       supported-markers ? [ ],
       options ? { },
       conflicts ? [ ],
+      ...
     }:
     assert version == 1;
     fix (toplevel: {


### PR DESCRIPTION
In uv 0.6 there is a new `revision` field and uv2nix fails because that field is passed in to a function that does not accept it. This PR changes that function to allow arbitrary additional arguments.