### PR TITLE
nit: fix a couple of typos

### DIFF
--- a/lib/workspace.nix
+++ b/lib/workspace.nix
@@ -249,8 +249,8 @@ fix (self: {
     Supports:
     - tool.uv.no-binary
     - tool.uv.no-build
-    - tool.uv.no-binary-packages
-    - tool.uv.no-build-packages
+    - tool.uv.no-binary-package
+    - tool.uv.no-build-package
   */
   loadConfig =
     # List of imported (lib.importTOML) pyproject.toml files from workspace from which to load config


### PR DESCRIPTION
It looks like we changed this from `no-binary-packages` to `no-binary-package` in 5b36429530387ce85cc586788eca54693602dea7, presumably to match upstream `uv`: https://docs.astral.sh/uv/reference/settings/#no-build-package