### PR TITLE
fix: enable downloading of uv on apple silicon

### DIFF
--- a/pkgs/uv-bin/default.nix
+++ b/pkgs/uv-bin/default.nix
@@ -1,3 +1,10 @@
+let
+  srcs = builtins.fromJSON (builtins.readFile ./srcs.json);
+  platformAliases = {
+    "arm64-apple-darwin" = "aarch64-apple-darwin";
+  };
+
+in
 {
   stdenv,
   lib,
@@ -6,9 +13,7 @@
 }:
 
 let
-  srcs = lib.importJSON ./srcs.json;
-  platform = stdenv.targetPlatform.config;
-
+  platform = platformAliases.${stdenv.targetPlatform.config} or stdenv.targetPlatform.config;
   sha256 = srcs.platforms.${platform} or (throw "Platform ${platform} not supported");
 
 in

--- a/pkgs/uv-bin/update.py
+++ b/pkgs/uv-bin/update.py
@@ -10,11 +10,6 @@ import re
 URL = "https://api.github.com/repos/astral-sh/uv/releases/latest"
 
 
-PLATFORM_ALIASES: dict[str, list[str]] = {
-    "aarch64-apple-darwin": ["arm64-apple-darwin"],
-}
-
-
 # Match an uv binary asset
 uv_re = re.compile(r"uv-(.+)\.tar\..+")
 
@@ -52,10 +47,7 @@ if __name__ == "__main__":
 
         with urllib.request.urlopen(sha256_url) as resp:
             data: bytes = resp.read()
-            value = data.split()[0].decode()
-            checksums[platform] = value
-            for alias in PLATFORM_ALIASES.get(platform, []):
-                checksums[alias] = value
+            checksums[platform] = data.split()[0].decode()
 
     with open("srcs.json", "w") as out:
         json.dump(


### PR DESCRIPTION
Alias platform in nix code since the nix platform does not exist elsewhere