### PR TITLE
support `upload_time` field in wheel metadata

### DIFF
--- a/lib/lock1.nix
+++ b/lib/lock1.nix
@@ -362,6 +362,7 @@ fix (self: {
           path ? null,
           hash ? null,
           size ? null,
+          upload_time ? null,
         }@whl:
         # Assert mutually exclusive args
         assert (whl ? url) -> (!whl ? filename && !whl ? path);
@@ -384,6 +385,9 @@ fix (self: {
         }
         // optionalAttrs (whl ? hash) {
           inherit hash;
+        }
+        // optionalAttrs (upload_time != null) {
+          inherit upload_time;
         };
 
       parseMetadata =


### PR DESCRIPTION
It got introduced in https://github.com/astral-sh/uv/pull/12968 and released in uv 0.6.15

Without this, lockfile parsing aborts with the following error:


       error: function 'parseWheel' called with unexpected argument 'upload_time'
       at /nix/store/2f6zv2mmb1arvxz1yksakmr6prai4xgm-source/lib/lock1.nix:359:9:
          358|       parseWheel =
          359|         {
             |         ^
          360|           url ? null,