### PR TITLE
Document optimising multi-member workspace dependency management

### DIFF
--- a/doc/src/patterns/applications.md
+++ b/doc/src/patterns/applications.md
@@ -8,36 +8,38 @@ For such cases `pyproject.nix` provides a utility function [`mkApplication`](htt
 
 ``` nix
 {
-    packages = forAllSystems (
-      system:
-      let
-        pythonSet = pythonSets.${system};
-        pkgs = nixpkgs.legacyPackages.${system};
-        inherit (pkgs.callPackages pyproject-nix.build.util { }) mkApplication;
-      in
-      {
-        # Create a derivation that wraps the venv but that only links package
-        # content present in pythonSet.hello-world.
-        #
-        # This means that files such as:
-        # - Python interpreters
-        # - Activation scripts
-        # - pyvenv.cfg
-        #
-        # Are excluded but things like binaries, man pages, systemd units etc are included.
-        default = util.mkApplication {
-          venv = pythonSet.mkVirtualEnv "application-env" workspace.deps.default;
-          package = pythonSet.hello-world;
+  packages = forAllSystems (
+    system:
+    let
+      pythonSet = pythonSets.${system};
+      pkgs = nixpkgs.legacyPackages.${system};
+      inherit (pkgs.callPackages pyproject-nix.build.util { }) mkApplication;
+    in
+    {
+      # Create a derivation that wraps the venv but that only links package
+      # content present in pythonSet.hello-world.
+      #
+      # This means that files such as:
+      # - Python interpreters
+      # - Activation scripts
+      # - pyvenv.cfg
+      #
+      # Are excluded but things like binaries, man pages, systemd units etc are included.
+      default = util.mkApplication {
+        venv = pythonSet.mkVirtualEnv "application-env" workspace.deps.default;
+        package = pythonSet.hello-world;
       };
 
-        # If you are building a package within a workspace, and want to avoid
-        # including the dependencies of all members of your workspace,
-        # instead of just the packages that your application needs.
-        app = util.mkApplication {
-          venv = pythonSet.mkVirtualEnv "application-env" {
-            app = [ ];
-          };
-          package = pythonSet.hello-world;
+      # If you are building a package within a workspace, and want to avoid
+      # including the dependencies of all members of your workspace,
+      # instead of just the packages that your application needs.
+      app = util.mkApplication {
+        venv = pythonSet.mkVirtualEnv "application-env" {
+          app = [ ];
         };
+        package = pythonSet.hello-world;
+      };
+    }
+  )
 }
 ```

--- a/doc/src/patterns/applications.md
+++ b/doc/src/patterns/applications.md
@@ -29,5 +29,15 @@ For such cases `pyproject.nix` provides a utility function [`mkApplication`](htt
           venv = pythonSet.mkVirtualEnv "application-env" workspace.deps.default;
           package = pythonSet.hello-world;
       };
+
+        # If you are building a package within a workspace, and want to avoid
+        # including the dependencies of all members of your workspace,
+        # instead of just the packages that your application needs.
+        app = util.mkApplication {
+          venv = pythonSet.mkVirtualEnv "application-env" {
+            app = [ ];
+          };
+          package = pythonSet.hello-world;
+        };
 }
 ```

--- a/templates/hello-world/flake.nix
+++ b/templates/hello-world/flake.nix
@@ -82,20 +82,22 @@
               pyprojectOverrides
             ]
           );
-
     in
     {
       # Package a virtual environment as our main application.
-      #
       # Enable no optional dependencies for production build.
-      packages.x86_64-linux.default = pythonSet.mkVirtualEnv "hello-world-env" workspace.deps.default;
+      #
+      # If you are building a package within a workspace, and want to avoid
+      # including the dependencies of all members of your workspace,
+      # instead of just the packages that your application needs,
+      # simply pass the dependency group for your package manually.
+      packages.x86_64-linux.default = pythonSet.mkVirtualEnv "hello-world-env" {
+        hello-world = [ ];
+      };
 
-      # Make hello runnable with `nix run`
-      apps.x86_64-linux = {
-        default = {
-          type = "app";
-          program = "${self.packages.x86_64-linux.default}/bin/hello";
-        };
+      apps.x86_64-linux.default = {
+        type = "app";
+        program = "${self.packages.x86_64-linux.default}/bin/hello";
       };
 
       # This example provides two different modes of development:


### PR DESCRIPTION
When reviewing the list of dependencies that are added to a virtualenv when using
```nix
default = util.mkApplication {
  venv = pythonSet.mkVirtualEnv "application-env" workspace.deps.default;
  package = pythonSet.hello-world;
};
```
you will find that if, you have more than one member in your workspace, all dependencies from all members of the workspace are added. This is not an issue in local development, but will bloat the size of containers when attempting to used the build program for an image, e.g. nix2container or dockerTools.

Instead, by specifying the name of the package that you want your container to hold, you can shrink this down to only what is necessary.

```nix
default = util.mkApplication {
  venv = pythonSet.mkVirtualEnv "application-env" {
    app = [ ];
  };
  package = pythonSet.hello-world;
};
```

NOTE: The content of this PR is adapted from https://github.com/pyproject-nix/uv2nix/issues/168#issuecomment-2821024092, but documenting something like this explicitly (and perhaps in more places?) would really improve the deployment experience.