### PR TITLE
uv-bin: add git to PATH

### DIFF
--- a/pkgs/uv-bin/default.nix
+++ b/pkgs/uv-bin/default.nix
@@ -10,6 +10,8 @@ in
   lib,
   fetchurl,
   autoPatchelfHook,
+  git,
+  makeWrapper,
 }:
 
 let
@@ -32,7 +34,9 @@ stdenv.mkDerivation (
       inherit sha256;
     };
 
-    nativeBuildInputs = lib.optional stdenv.isLinux autoPatchelfHook;
+    nativeBuildInputs = [
+      makeWrapper
+    ] ++ lib.optional stdenv.isLinux autoPatchelfHook;
     buildInputs = lib.optional stdenv.isLinux stdenv.cc.cc;
 
     dontConfigure = true;
@@ -41,6 +45,10 @@ stdenv.mkDerivation (
     installPhase = ''
       mkdir -p $out/bin
       mv uv* $out/bin
+    '';
+
+    postFixup = ''
+      wrapProgram $out/bin/uv --prefix PATH : ${git}/bin
     '';
 
     meta = {


### PR DESCRIPTION
The `uv-bin` derivation in `uv2nix` does not make `git` purely available for `uv`. This becomes an issue, when `nix` is used together with the `--ignore-environment` flag.

`uv` uses `git`, when a git repository is referenced in `pyproject.toml`, e.g.:
```toml
dependencies = [
    "kevm-pyk@git+https://github.com/runtimeverification/evm-semantics.git@v1.0.841#subdirectory=kevm-pyk",
]
```

The git issue can be replicated by running `nix shell github:pyproject-nix/uv2nix#uv-bin --ignore-environment --command uv sync` in a project that uses these git references in `pyproject.toml`.

This pull request fixes this issue by adding `git` to the PATH environment variable for `uv-bin` by wrapping it with `wrapProgram`.