### PR TITLE
Add section on advanced (native) build systems in editable mode

### DIFF
--- a/doc/src/SUMMARY.md
+++ b/doc/src/SUMMARY.md
@@ -20,6 +20,7 @@
   - [Installing non-PyPI packages](./patterns/nixpkgs-wheels.md)
   - [Private packages](./patterns/private-deps.md)
   - [Patching packages](./patterns/patching-deps.md)
+  - [Advanced build systems (editables)](./patterns/advanced-build-systems.md)
 
 - [Platform quirks](./platform-quirks.md)
 

--- a/doc/src/patterns/advanced-build-systems.md
+++ b/doc/src/patterns/advanced-build-systems.md
@@ -1,0 +1,31 @@
+# Advanced build systems (editables)
+
+When using more advanced build systems, such as `cython` which builds native dependencies, or `meson-python` which relies on import hooks to dynamically perform recompilation on import an additional step needs to be taken to bridge the gap between the sandboxed Nix build and the source tree:
+```nix
+pkgs.mkShell {
+  packages = [
+    virtualenv
+    pkgs.uv
+
+    # Add build-editable package from pyproject.nix
+    pyproject-nix.packages.${system}.build-editable
+  ];
+
+  env = {
+    UV_NO_SYNC = "1";
+    UV_PYTHON = python.interpreter;
+    UV_PYTHON_DOWNLOADS = "never";
+  };
+
+  shellHook = ''
+    unset PYTHONPATH
+    export REPO_ROOT=$(git rev-parse --show-toplevel)
+
+    # Re-run editable package build for side effects
+    build-editable
+  '';
+};
+```
+
+Whenever you want to perform a build invoke `build-editable` which will in turn invoke your build system and write side effects such as `.so`'s in-place in your source tree.
+For most (all?) pure-Python build systems this is not relevant.


### PR DESCRIPTION
Note: Uses https://github.com/pyproject-nix/pyproject.nix/pull/339 which is not yet merged.