### PR TITLE
doc: simpler nixpkgs wheels usage

### DIFF
--- a/doc/src/patterns/nixpkgs-wheels.md
+++ b/doc/src/patterns/nixpkgs-wheels.md
@@ -24,14 +24,11 @@ let
 in
 mkShell {
   packages = [ pkgs.uv python ];
-  shellHook = ''
-    ln -sfn ${uv-links} .uv-links
-    export UV_FIND_LINKS=$(realpath -s .uv-links)
-  '';
+  env.UV_FIND_LINKS = uv-links;
 }
 ```
 
-To be able to read the sources from a Flake evaluation you will also have to override the `seccomp` package sources, as `.uv-links` is not added to Git.
+To be able to read the sources from a Flake evaluation you will also have to override the `seccomp` package sources:
 
 ``` nix
 let


### PR DESCRIPTION
Once upon a time, `uv` would *always* generate relative paths
to wheels it discovered in `UV_FIND_LINKS`. See
<https://github.com/pyproject-nix/pyproject.nix/issues/267#issuecomment-2702210412>.
This required us to do some cleverness to create a relative
path that would work across machines, so we landed on this
gitignored `.uv-links` folder.

However, it appears `uv` has started behaving differently: if it
discovers an absolute path to a wheel file, stores that absolute path.
This is great for us, as absolute `/nix/store/...` paths are the same
everywhere.
