### PR TITLE
fix: subdirectory when sourceRoot ≠ "source"

### DIFF
--- a/dev/checks.nix
+++ b/dev/checks.nix
@@ -361,6 +361,14 @@ let
         };
       };
 
+      urlSubdirectory = mkCheck {
+        name = "url-subdirectory";
+        root = ../lib/fixtures/url-subdirectory;
+        spec = {
+          url-subdirectory = [ ];
+        };
+      };
+
       editable-workspace =
         let
           workspaceRoot = ../lib/fixtures/workspace;

--- a/lib/build.nix
+++ b/lib/build.nix
@@ -492,7 +492,9 @@ in
           ));
       }
       // optionalAttrs (subdirectory != null) {
-        sourceRoot = "source/${subdirectory}";
+        postUnpack = ''
+          sourceRoot="$sourceRoot/${subdirectory}"
+        '';
       }
       // optionalAttrs stdenv.isDarwin {
         sandboxProfile = darwinSandboxProfile;

--- a/lib/fixtures/url-subdirectory/pyproject.toml
+++ b/lib/fixtures/url-subdirectory/pyproject.toml
@@ -1,0 +1,22 @@
+[project]
+name = "url-subdirectory"
+version = "0.1.0"
+description = "Add your description here"
+readme = "README.md"
+authors = [
+    { name = "adisbladis", email = "adisbladis@gmail.com" }
+]
+requires-python = ">=3.12"
+dependencies = [
+    "hatchling",
+]
+
+[project.scripts]
+url-subdirectory = "url_subdirectory:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.uv.sources]
+hatchling = { url = "https://github.com/pypa/hatch/archive/hatchling-v1.27.0.tar.gz", subdirectory = "backend" }

--- a/lib/fixtures/url-subdirectory/src/url_subdirectory/__init__.py
+++ b/lib/fixtures/url-subdirectory/src/url_subdirectory/__init__.py
@@ -1,0 +1,2 @@
+def main() -> None:
+    print("Hello from url-subdirectory!")

--- a/lib/fixtures/url-subdirectory/uv.lock
+++ b/lib/fixtures/url-subdirectory/uv.lock
@@ -1,0 +1,71 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"
+
+[[package]]
+name = "hatchling"
+version = "1.27.0"
+source = { url = "https://github.com/pypa/hatch/archive/hatchling-v1.27.0.tar.gz", subdirectory = "backend" }
+dependencies = [
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "pluggy" },
+    { name = "trove-classifiers" },
+]
+sdist = { hash = "sha256:c5d576a04bbc3940c71dc899da35a9cfe644044a6e4e70549f41d964d6331625" }
+
+[package.metadata]
+requires-dist = [
+    { name = "packaging", specifier = ">=24.2" },
+    { name = "pathspec", specifier = ">=0.10.1" },
+    { name = "pluggy", specifier = ">=1.0.0" },
+    { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=1.2.2" },
+    { name = "trove-classifiers" },
+]
+
+[[package]]
+name = "packaging"
+version = "24.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/63/68dbb6eb2de9cb10ee4c9c14a0148804425e13c4fb20d61cce69f53106da/packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f", size = 163950, upload-time = "2024-11-08T09:47:47.202Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/ef/eb23f262cca3c0c4eb7ab1933c3b1f03d021f2c48f54763065b6f0e321be/packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759", size = 65451, upload-time = "2024-11-08T09:47:44.722Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "0.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712", size = 51043, upload-time = "2023-12-10T22:30:45Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08", size = 31191, upload-time = "2023-12-10T22:30:43.14Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/2d/02d4312c973c6050a18b314a5ad0b3210edb65a906f868e31c111dede4a6/pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1", size = 67955, upload-time = "2024-04-20T21:34:42.531Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669", size = 20556, upload-time = "2024-04-20T21:34:40.434Z" },
+]
+
+[[package]]
+name = "trove-classifiers"
+version = "2025.1.15.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/cb/8f6a91c74049180e395590901834d68bef5d6a2ce4c9ca9792cfadc1b9b4/trove_classifiers-2025.1.15.22.tar.gz", hash = "sha256:90af74358d3a01b3532bc7b3c88d8c6a094c2fd50a563d13d9576179326d7ed9", size = 16236, upload-time = "2025-01-15T22:41:11.712Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/c5/6422dbc59954389b20b2aba85b737ab4a552e357e7ea14b52f40312e7c84/trove_classifiers-2025.1.15.22-py3-none-any.whl", hash = "sha256:5f19c789d4f17f501d36c94dbbf969fb3e8c2784d008e6f5164dd2c3d6a2b07c", size = 13610, upload-time = "2025-01-15T22:41:08.949Z" },
+]
+
+[[package]]
+name = "url-subdirectory"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "hatchling" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "hatchling", url = "https://github.com/pypa/hatch/archive/hatchling-v1.27.0.tar.gz", subdirectory = "backend" }]


### PR DESCRIPTION
... which is always the case for url type sources. This fixes the implementation added in #284. It never triggered for us because we always use overlays 🙄 

Added a regression test this time 👍 