### PR TITLE
fix(build): don't resolve empty extra-build-dependencies for local pa…

### DIFF
--- a/lib/build.nix
+++ b/lib/build.nix
@@ -259,7 +259,7 @@ in
         // {
           nativeBuildInputs =
             (attrs.nativeBuildInputs or [ ])
-            ++ optionals (package-extra-build-dependencies != [ ]) (
+            ++ optionals (package-extra-build-dependencies != { }) (
               resolveBuildSystem package-extra-build-dependencies
             );
 


### PR DESCRIPTION
This bug was identified by Claude Fable 5.0. I believe that the change is straight-forward enough, but apologies if AI-driven PRs are against this project's policies.

A minimal reproducer (one local package, hatchling resolvable from uv.lock, no build-systems overlay) can be found at https://github.com/mcpeanutbutter/uv2nix-empty-build-system-repro.

I verified that the proposed one-line change to the reproducer builds. If preferred I'd be happy to add a regression check to `dev/checks.nix` (e.g. asserting a local package without extra-build-dependencies doesn't get the setuptools/wheel fallback).

Claude's description of the issue follows below:

> `mkPackageExtraBuildDependencies` returns an attrset (`{ }` when no extra-build-dependencies are configured), but the local-package builder guards it with `!= [ ]` - always true for an attrset - so every local package calls `resolveBuildSystem { }`, which pyproject.nix resolves to its `{ setuptools, wheel }` PEP 517 fallback. The remote-package builder introduced in the same commit (afe62f1e97) uses the correct `!= { }`; this aligns the local builder with it.
> 
> Consequences of the current behavior:
> 
> - with the `pyproject-build-systems` overlay: setuptools + wheel are silently added to every local package's `nativeBuildInputs`, even with extra-build-dependencies unset;
> - without the overlay (wheels-only closure, no setuptools in `uv.lock`): evaluation fails with `error: attribute 'setuptools' missing`, even though the package's declared build system resolves fine.