### PR TITLE
treewide: stdenv.is* -> stdenv.hostPlatform.is*

### DIFF
--- a/dev/checks.nix
+++ b/dev/checks.nix
@@ -738,7 +738,7 @@ in
 # builder impl  -> sourcePreference
 mkChecks "wheel"
 // mkChecks "sdist"
-// (lib.optionalAttrs (!stdenv.isDarwin) {
+// (lib.optionalAttrs (!stdenv.hostPlatform.isDarwin) {
   no-compile-bytecode =
     let
       interpreter = pkgs.python3;

--- a/flake.nix
+++ b/flake.nix
@@ -214,7 +214,7 @@
               uv2nix = self.lib;
             };
           in
-          lib.optionalAttrs (!lib.hasSuffix "-freebsd" system && !pkgs'.stdenv.isDarwin) {
+          lib.optionalAttrs (!lib.hasSuffix "-freebsd" system && !pkgs'.stdenv.hostPlatform.isDarwin) {
             # Fails on aarch64-darwin with oom
             trivial-22_11 = checks'.trivial;
           }

--- a/lib/build.nix
+++ b/lib/build.nix
@@ -265,7 +265,7 @@ in
 
           buildInputs =
             (attrs.buildInputs or [ ])
-            ++ (optionals (stdenv.isDarwin && darwinMinVersionHook != null) [
+            ++ (optionals (stdenv.hostPlatform.isDarwin && darwinMinVersionHook != null) [
               (darwinMinVersionHook stdenv.targetPlatform.darwinSdkVersion)
             ]);
 
@@ -277,7 +277,7 @@ in
             dependency-groups = mapAttrs (_: mkSpec) package.dev-dependencies;
           };
         }
-        // optionalAttrs stdenv.isDarwin {
+        // optionalAttrs stdenv.hostPlatform.isDarwin {
           sandboxProfile = darwinSandboxProfile;
         }
         // {
@@ -508,7 +508,7 @@ in
           optional (hasSuffix ".zip" (self.src.passthru.url or "")) unzip
           ++ optional (format == "pyproject") pyprojectHook
           ++ optional (format == "wheel") pyprojectWheelHook
-          ++ optional (format == "wheel" && stdenv.isLinux) autoPatchelfHook
+          ++ optional (format == "wheel" && stdenv.hostPlatform.isLinux) autoPatchelfHook
           ++ optionals (package-extra-build-dependencies != { }) (
             resolveBuildSystem package-extra-build-dependencies
           );
@@ -522,7 +522,7 @@ in
         # Add wheel utils
         buildInputs =
           # Add manylinux platform dependencies.
-          optionals (stdenv.isLinux && stdenv.hostPlatform.libc == "glibc") (
+          optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.libc == "glibc") (
             unique (
               concatMap (
                 tag:
@@ -541,7 +541,7 @@ in
               ) selectedWheel'.platformTags
             )
           )
-          ++ (optional (stdenv.isDarwin && darwinMinVersionHook != null) (
+          ++ (optional (stdenv.hostPlatform.isDarwin && darwinMinVersionHook != null) (
             darwinMinVersionHook stdenv.targetPlatform.darwinSdkVersion
           ));
       }
@@ -550,7 +550,7 @@ in
           sourceRoot="$sourceRoot/${subdirectory}"
         '';
       }
-      // optionalAttrs stdenv.isDarwin {
+      // optionalAttrs stdenv.hostPlatform.isDarwin {
         sandboxProfile = darwinSandboxProfile;
       }
     );

--- a/pkgs/uv-bin/default.nix
+++ b/pkgs/uv-bin/default.nix
@@ -32,8 +32,8 @@ stdenv.mkDerivation (
       inherit sha256;
     };
 
-    nativeBuildInputs = lib.optional stdenv.isLinux autoPatchelfHook;
-    buildInputs = lib.optional stdenv.isLinux stdenv.cc.cc;
+    nativeBuildInputs = lib.optional stdenv.hostPlatform.isLinux autoPatchelfHook;
+    buildInputs = lib.optional stdenv.hostPlatform.isLinux stdenv.cc.cc;
 
     dontConfigure = true;
     dontBuild = true;


### PR DESCRIPTION
Nixpkgs deprecated the former.